### PR TITLE
add button to restart lomiri, fix #9

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -4,6 +4,7 @@ import Ubuntu.Components 1.3
 import Ubuntu.Components.Pickers 1.3
 import Qt.labs.settings 1.0
 import Indicator 1.0
+import io.thp.pyotherside 1.4 //for Python
 
 MainView {
     id: root
@@ -14,10 +15,10 @@ MainView {
 
     width: units.gu(45)
     height: units.gu(75)
-    
+
     Settings {
         id: settings
-    
+
         property bool autoDarkMode: false
         property string startTime: "19:00"
         property string endTime: "06:00"
@@ -32,7 +33,7 @@ MainView {
 
         Flickable {
             id: flickable
-            
+
             anchors {
                 top: header.bottom
                 left: parent.left
@@ -53,69 +54,69 @@ MainView {
                     margins: units.gu(2)
                 }
                 spacing: units.gu(1)
-                
+
                 Label{
                     Layout.fillWidth: true
-                    
+
                     text: i18n.tr("What is this?")
                     font.bold: true
                     textSize: Label.Large
                     elide: Text.ElideRight
                 }
-                
+
                 Label{
                     Layout.fillWidth: true
-                    
+
                     text: i18n.tr("This is a proof of concept for an indicator to switch between Ambiance and Suru Dark theme.")
                     wrapMode: Text.Wrap
                 }
-                
+
                 Label{
                     Layout.fillWidth: true
-                    
+
                     text: i18n.tr("What does it exactly do?")
                     font.bold: true
                     textSize: Label.Large
                     elide: Text.ElideRight
                 }
-                
+
                 Label{
                     Layout.fillWidth: true
-                    
+
                     text: i18n.tr('It modifies the theme in the config file "/home/phablet/.config/ubuntu-ui-toolkit/theme.ini"')
                     wrapMode: Text.Wrap
                 }
-                
+
                 Label{
                     Layout.fillWidth: true
-                    
+
                     text: i18n.tr("How does it work?")
                     font.bold: true
                     textSize: Label.Large
                     elide: Text.ElideRight
                 }
-                
+
                 Label{
                     Layout.fillWidth: true
-                    
+
                     text: i18n.tr('Enabling Dark Mode from the indicator will switch to the theme "Suru Dark". ')
                         + i18n.tr('Disabling it will revert back to "Ambiance". ')
                         + i18n.tr('There is also an option to switch the theme automatically based on the time.')
                     wrapMode: Text.Wrap
                 }
-                
+
                 Label{
                     Layout.fillWidth: true
-                    
+
                     text: i18n.tr("Anything else?")
                     font.bold: true
                     textSize: Label.Large
                     elide: Text.ElideRight
                 }
-                
+
                 Label{
                     Layout.fillWidth: true
-                    
+
                     text: "- " + i18n.tr("The theme change won't take effect on currently open apps until they are restarted. ")
                         + "\n\n- " + i18n.tr("Time accuracy for automatically switching to a theme will be based on the set time interval for checking the time.")
                         + "\n\n- " + i18n.tr("Suru Dark theme support varies across apps. There are apps that just works while some will only have partial support and some won't even respect it.")
@@ -124,19 +125,19 @@ MainView {
                 }
             }
         }
-        
+
         ColumnLayout {
             id: installColumn
-            
+
             anchors {
                 left: parent.left
                 bottom: parent.bottom
                 right: parent.right
                 bottomMargin: units.gu(2)
             }
-            
+
             spacing: units.gu(1)
-            
+
             Rectangle {
                 height: units.gu(0.3)
                 color: theme.palette.normal.base
@@ -145,10 +146,10 @@ MainView {
                     right: parent.right
                 }
             }
-            
+
             ListItem {
                 id: switchAuto
-                
+
                 property bool bindValue: settings.autoDarkMode
                 property bool switchValue: bindValue
 
@@ -156,7 +157,7 @@ MainView {
 
                 ListItemLayout {
                     id: listItemLayout
-                    
+
                     anchors.centerIn: parent
                     title.text: i18n.tr("Auto switch")
                     subtitle.text: i18n.tr("Automatically switch theme based on time")
@@ -181,30 +182,30 @@ MainView {
                 onClicked: {
                     switchValue = !bindValue
                 }
-                
+
                 onSwitchValueChanged: {
                     settings.autoDarkMode = switchValue
                 }
             }
-            
+
             ListItem {
                 id: startTimeListitem
-                
+
                 property date date: Date.fromLocaleString(Qt.locale(), settings.startTime, "hh:mm")
 
                 visible: settings.autoDarkMode
                 Layout.fillWidth: true
-                
+
                 onDateChanged: {
                     settings.startTime = date.toLocaleString(Qt.locale(), "hh:mm")
                 }
-                
+
                 onClicked: PickerPanel.openDatePicker(startTimeListitem, "date", "Hours|Minutes")
-                
+
                 ListItemLayout {
                     anchors.centerIn: parent
                     title.text: i18n.tr("Start time")
-                    
+
                     Label {
                         anchors.verticalCenter: parent.verticalCenter
                         textSize: Label.Large
@@ -213,24 +214,24 @@ MainView {
                     }
                 }
             }
-            
+
             ListItem {
                 id: endTimeListitem
-                
+
                 property date date: Date.fromLocaleString(Qt.locale(), settings.endTime, "hh:mm")
 
                 visible: settings.autoDarkMode
                 Layout.fillWidth: true
-                
+
                 onDateChanged: {
                     settings.endTime = date.toLocaleString(Qt.locale(), "hh:mm")
                 }
-                
+
                 onClicked: PickerPanel.openDatePicker(endTimeListitem, "date", "Hours|Minutes")
-                
+
                 ListItemLayout {
                     title.text: i18n.tr("End time")
-                    
+
                     Label {
                         textSize: Label.Large
                         text: endTimeListitem.date.toLocaleTimeString(Qt.locale(),Locale.ShortFormat)
@@ -239,7 +240,7 @@ MainView {
                 }
             }
 
-            
+
             ListItem {
                 id: timeIntervalListItem
 
@@ -247,18 +248,18 @@ MainView {
                 height: Math.max(implicitHeight, timeLItemLayout.height)
                 Layout.fillWidth: true
                 divider.visible: false
-                
+
                 ListItemLayout {
                     id: timeLItemLayout
-                    
+
                     anchors.centerIn: parent
                     title.text: i18n.tr("Time check interval (minutes)")
                     summary.text: i18n.tr("This determines how often the indicator will check the time and if there's a need to toggle the theme.")
-                    summary.wrapMode: Text.WordWrap 
+                    summary.wrapMode: Text.WordWrap
 
                     TextField {
                         id: checkTimeInterval
-                        
+
                         width: units.gu(7)
                         hasClearButton: false
 
@@ -284,44 +285,59 @@ MainView {
                     }
                 }
             }
-            
+
             Label {
                 text: i18n.tr("Warning: The smaller the value, the higher the impact to battery. This takes effect even when auto-switching is disabled.")
                 color: theme.palette.normal.negative
                 wrapMode: Text.Wrap
                 textSize: Label.Small
-                
+
                 Layout.alignment: Qt.AlignLeft
                 Layout.fillWidth: true
                 Layout.leftMargin: units.gu(2)
             }
-            
 
-            Button {
-                id: installButton
-                
+            Row {
                 anchors {
                     horizontalCenter: parent.horizontalCenter
                 }
+                spacing: units.gu(2)
+                Button {
+                    id: installButton
 
-                text: !Indicator.isInstalled ? i18n.tr("Install Indicator") : i18n.tr("Uninstall Indicator")
-                onClicked: {
-                    if (Indicator.isInstalled) {
-                        Indicator.uninstall();
-                    } else {
-                        Indicator.install();
+                    text: !Indicator.isInstalled ? i18n.tr("Install Indicator") : i18n.tr("Uninstall Indicator")
+                    onClicked: {
+                        if (Indicator.isInstalled) {
+                            Indicator.uninstall();
+                        } else {
+                            Indicator.install();
+                        }
+                    }
+                    color: !Indicator.isInstalled ? UbuntuColors.green : UbuntuColors.red
+                }
+
+                Button {
+                    id: restartButton
+                    visible: false
+
+                    text: i18n.tr("Restart Lomiri/Unity8")
+                    onClicked: {
+                            py.call('os.system', ["restart unity8"], function (result) {
+                            // TODO: add error handling
+                            });
+
                     }
                 }
-                color: !Indicator.isInstalled ? UbuntuColors.green : UbuntuColors.red
             }
-            
+
+
             Label {
                 id: message
 
                 text: i18n.tr("Uninstall the indicator here before uninstalling the app!") + "\n"
                 horizontalAlignment: Text.AlignHCenter
                 color: UbuntuColors.red
-                
+
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillWidth: true
             }
@@ -335,6 +351,7 @@ MainView {
             if (success) {
                 message.text = i18n.tr("Successfully installed!") + "\n" + i18n.tr("Please reboot or restart Lomiri/Unity8");
                 message.color = UbuntuColors.green;
+                restartButton.visible = true;
             }
             else {
                 message.text = i18n.tr("Failed to install");
@@ -346,6 +363,7 @@ MainView {
             if (success) {
                 message.text = i18n.tr("Successfully uninstalled!") + "\n" + i18n.tr("Please reboot or restart Lomiri/Unity8");
                 message.color = UbuntuColors.green;
+                restartButton.visible = true;
             }
             else {
                 message.text = i18n.tr("Failed to uninstall");
@@ -353,4 +371,15 @@ MainView {
             }
         }
     }
+
+    //initiate a python component for calls to python commands
+    Python {
+        id: py
+
+        Component.onCompleted: {
+            //this works as the import statement in a python script
+            importModule('os', function() { console.log("DEBUG: python module os loaded"); });
+        }
+    }
+
 }


### PR DESCRIPTION
This PR will add a button for restarting lomiri fixing #9.

The button will be on the right side of the install/uninstall button and only visible after installing/uninstalling the indicator.

![screenshot20200619_220904515](https://user-images.githubusercontent.com/37637312/85176248-b410ac80-b279-11ea-8755-7f3f42b87416.png)

P.S. I do LOVE this python implementation. No hacking in c++ involved to get this done. :grinning: 
