### PR TITLE
make indicator strings translatable and update German translation

### DIFF
--- a/indicator/kugiigi-indicator-darkmode.py
+++ b/indicator/kugiigi-indicator-darkmode.py
@@ -30,21 +30,21 @@ class DarkModeIndicator(object):
     AUTO_ACTION = "auto"
     SETTINGS_ACTION = 'settings'
     MAIN_SECTION = 0
-    
+
     AMBIANCE_TEXT = "Ubuntu.Components.Themes.Ambiance"
     SURUDARK_TEXT = "Ubuntu.Components.Themes.SuruDark"
     ENABLED_ICON = "weather-clear-night-symbolic"
     DISABLED_ICON = "night-mode"
-    
+
     config_file = "/home/phablet/.config/indicator-darkmode/indicator-darkmode.conf"  # TODO don't hardcode this
     theme_ini = "/home/phablet/.config/ubuntu-ui-toolkit/theme.ini"
-    
+
     config_parser = ConfigParser()
     # Do not convert attribute names to lowercase
     config_parser.optionxform = str
-    
+
     theme_parser = ConfigParser()
-    
+
     def __init__(self, bus):
         self.bus = bus
         self.action_group = Gio.SimpleActionGroup()
@@ -54,7 +54,7 @@ class DarkModeIndicator(object):
         self.current_switch_icon = self.DISABLED_ICON
 
     def get_text(self, condition):
-        text = 'Indicator Suru Dark Mode'
+        text = _('Indicator Suru Dark Mode')
         return text
 
     def get_icon(self, condition):
@@ -63,19 +63,19 @@ class DarkModeIndicator(object):
 
     def toggle_mode_activated(self, action, data):
         self.log(message='toggle_mode_activated')
-        
+
         if self.autoSwitchEnabled() == False:
             self.toggleTheme()
-        
+
         self.update_darkmode(set_timeout=False)
-        
+
     def auto_mode_activated(self, action, data):
         self.log(message='auto_mode_activated')
-        
+
         self.toggleAuto()
-        
+
         self.update_darkmode()
-        
+
     def settings_action_activated(self, action, data):
         self.log(message='settings_action_activated')
         subprocess.Popen(shlex.split('ubuntu-app-launch indicator-darkmode.kugiigi_indicator-darkmode'))
@@ -84,15 +84,15 @@ class DarkModeIndicator(object):
     def _setup_actions(self):
         root_action = Gio.SimpleAction.new_stateful(self.ROOT_ACTION, None, self.root_state())
         self.action_group.insert(root_action)
-        
+
         auto_action = Gio.SimpleAction.new_stateful(self.AUTO_ACTION, None, GLib.Variant.new_boolean(self.autoSwitchEnabled()))
         auto_action.connect('activate', self.auto_mode_activated)
         self.action_group.insert(auto_action)
-        
+
         current_action = Gio.SimpleAction.new_stateful(self.CURRENT_ACTION, None, GLib.Variant.new_boolean(self.current_state()))
         current_action.connect('activate', self.toggle_mode_activated)
         self.action_group.insert(current_action)
-        
+
         settings_action = Gio.SimpleAction.new(self.SETTINGS_ACTION, None)
         settings_action.connect('activate', self.settings_action_activated)
         self.action_group.insert(settings_action)
@@ -100,17 +100,17 @@ class DarkModeIndicator(object):
 
     def _create_section(self):
         section = Gio.Menu()
-        
-        auto_menu_item = Gio.MenuItem.new('Scheduled', 'indicator.{}'.format(self.AUTO_ACTION))
+
+        auto_menu_item = Gio.MenuItem.new(_('Scheduled'), 'indicator.{}'.format(self.AUTO_ACTION))
         auto_menu_item.set_attribute_value('x-canonical-type', GLib.Variant.new_string('com.canonical.indicator.switch'))
         section.append_item(auto_menu_item)
-        
+
         if self.autoSwitchEnabled() == False:
-            current_menu_item = Gio.MenuItem.new('Suru Dark Mode', 'indicator.{}'.format(self.CURRENT_ACTION))
+            current_menu_item = Gio.MenuItem.new(_('Suru Dark Mode'), 'indicator.{}'.format(self.CURRENT_ACTION))
             current_menu_item.set_attribute_value('x-canonical-type', GLib.Variant.new_string('com.canonical.indicator.switch'))
             section.append_item(current_menu_item)
-        
-        settings_menu_item = Gio.MenuItem.new('Suru Dark Mode Settings...', 'indicator.{}'.format(self.SETTINGS_ACTION))
+
+        settings_menu_item = Gio.MenuItem.new(_('Suru Dark Mode Settings...'), 'indicator.{}'.format(self.SETTINGS_ACTION))
         section.append_item(settings_menu_item)
 
 
@@ -119,7 +119,7 @@ class DarkModeIndicator(object):
     def _setup_menu(self):
         self.sub_menu.insert_section(self.MAIN_SECTION, 'Suru Dark Mode', self._create_section())
 
-        root_menu_item = Gio.MenuItem.new('Suru Dark Mode', 'indicator.{}'.format(self.ROOT_ACTION))
+        root_menu_item = Gio.MenuItem.new(_('Suru Dark Mode'), 'indicator.{}'.format(self.ROOT_ACTION))
         root_menu_item.set_attribute_value('x-canonical-type', GLib.Variant.new_string('com.canonical.indicator.root'))
         root_menu_item.set_submenu(self.sub_menu)
         self.menu.append_item(root_menu_item)
@@ -128,78 +128,78 @@ class DarkModeIndicator(object):
         self.sub_menu.remove(self.MAIN_SECTION)
         self.sub_menu.insert_section(self.MAIN_SECTION, 'Suru Dark Mode', self._create_section())
 
-    def update_darkmode(self, set_timeout=True): 
+    def update_darkmode(self, set_timeout=True):
         autoEnabled = self.autoSwitchEnabled()
         if autoEnabled == True:
             currentTheme = self.current_theme()
             startTime = self.startTime().split(':')
             endTime = self.endTime().split(':')
-            
+
             now = datetime.now()
-            
+
             start = now.replace(hour=int(startTime[0]), minute=int(startTime[1]), second=0, microsecond=0)
-            
+
             end = now.replace(hour=int(endTime[0]), minute=int(endTime[1]), second=0, microsecond=0)
             reverseLogic = (int(startTime[0]) > int(endTime[0])) or (int(startTime[0]) == int(endTime[0]) and int(startTime[1]) > int(endTime[1]))
-            
+
             if (((reverseLogic == False and now >= start and now <= end) or (reverseLogic == True and ((now >= start and now >= end) or (now <= start and now <= end)))) and currentTheme != self.SURUDARK_TEXT) \
                 or (((reverseLogic == False and (now < start or now > end)) or (reverseLogic == True and now < start and now > end)) and currentTheme != self.AMBIANCE_TEXT):
                 self.toggleTheme()
-        
-        
+
+
         self.log(message='Suru dark enabled: {}'.format(str(self.current_state())))
-            
+
         self.action_group.change_action_state(self.ROOT_ACTION, self.root_state())
         self.action_group.change_action_state(self.AUTO_ACTION, GLib.Variant.new_boolean(self.autoSwitchEnabled()))
         self.action_group.change_action_state(self.CURRENT_ACTION, GLib.Variant.new_boolean(self.current_state()))
         self._update_menu()
-        
+
         if set_timeout == True and autoEnabled == True:
             interval = self.checkInterval()
-            
+
             nowStamp = time.mktime(now.timetuple())
             startStamp = time.mktime(start.timetuple())
             endStamp = time.mktime(end.timetuple())
-            
+
             startDiff = int((startStamp - nowStamp) / 60)
             endDiff = int((endStamp - nowStamp) / 60)
-            
+
             if startDiff > 0 and startDiff < interval:
                 interval = startDiff + 1
             elif endDiff > 0 and endDiff < interval:
                 interval = endDiff + 1
-                
+
             # Stop timeout and recreate another so that we get the value of interval minutes in real time
-            GLib.timeout_add_seconds(60 * interval, self.update_darkmode)  
-                 
+            GLib.timeout_add_seconds(60 * interval, self.update_darkmode)
+
         return False
-        
+
     def toggleTheme(self):
         self.theme_parser.read(self.theme_ini)
         general_config = self.theme_parser["General"]
         currentTheme = self.current_theme()
-        
+
         if currentTheme == self.SURUDARK_TEXT:
             general_config['theme'] = self.AMBIANCE_TEXT
             self.current_switch_icon = self.DISABLED_ICON
         else:
             general_config['theme'] = self.SURUDARK_TEXT
             self.current_switch_icon = self.ENABLED_ICON
-        
+
         #Write changes back to file
         with open(self.theme_ini, 'w') as conf:
             self.theme_parser.write(conf, space_around_delimiters=False)
-            
+
     def toggleAuto(self):
         self.config_parser.read(self.config_file)
         general_config = self.config_parser["General"]
         autoState = self.autoSwitchEnabled()
-        
+
         if autoState == True:
             general_config['autoDarkMode'] = 'false'
         else:
             general_config['autoDarkMode'] = 'true'
-        
+
         #Write changes back to file
         with open(self.config_file, 'w') as conf:
             self.config_parser.write(conf, space_around_delimiters=False)
@@ -210,18 +210,18 @@ class DarkModeIndicator(object):
 
         self.bus.export_action_group(BUS_OBJECT_PATH, self.action_group)
         self.menu_export = self.bus.export_menu_model(BUS_OBJECT_PATH_PHONE, self.menu)
-        
+
         self.update_darkmode()
 
     def root_state(self):
         vardict = GLib.VariantDict.new()
-        
+
         currentState = self.current_state()
         if currentState == True:
             vardict.insert_value('visible', GLib.Variant.new_boolean(True))
         else:
             vardict.insert_value('visible', GLib.Variant.new_boolean(False))
-        
+
         vardict.insert_value('title', GLib.Variant.new_string('Suru Dark Mode'))
 
         icon = Gio.ThemedIcon.new(self.current_icon())
@@ -236,7 +236,7 @@ class DarkModeIndicator(object):
             return general_config['autoDarkMode'].strip() == 'true'
         except:
             return False
-        
+
     def checkInterval(self):
         try:
             self.config_parser.read(self.config_file)
@@ -248,8 +248,8 @@ class DarkModeIndicator(object):
                 return 15
         except:
             return 15
-        
-        
+
+
     def startTime(self):
         try:
             self.config_parser.read(self.config_file)
@@ -261,7 +261,7 @@ class DarkModeIndicator(object):
                 return "19:00"
         except:
             return "19:00"
-        
+
     def endTime(self):
         try:
             self.config_parser.read(self.config_file)
@@ -273,7 +273,7 @@ class DarkModeIndicator(object):
                 return "06:00"
         except:
             return "06:00"
-            
+
     def logging(self):
         try:
             self.config_parser.read(self.config_file)
@@ -289,12 +289,12 @@ class DarkModeIndicator(object):
         else:
             icon = self.current_switch_icon
         return icon
-        
+
     def current_theme(self):
         self.theme_parser.read(self.theme_ini)
         general_config = self.theme_parser["General"]
         return general_config['theme'].strip()
-        
+
     def current_state(self):
         currentValue = self.current_theme()
         if currentValue == self.SURUDARK_TEXT:
@@ -302,7 +302,7 @@ class DarkModeIndicator(object):
         else:
             state = False
         return state
-        
+
     def log(self, message=""):
         if self.logging() == True:
             logger.debug(message)

--- a/indicator/kugiigi-indicator-darkmode.py
+++ b/indicator/kugiigi-indicator-darkmode.py
@@ -12,6 +12,10 @@ from gi.repository import GLib
 from configparser import ConfigParser
 from datetime import datetime, timedelta
 
+import gettext
+t = gettext.translation('indicator-darkmode', fallback=True, localedir='/opt/click.ubuntu.com/indicator-darkmode.kugiigi/current/share/locale/')  # TODO don't hardcode this
+_ = t.gettext
+
 BUS_NAME = 'com.kugiigi.indicator.darkmode'
 BUS_OBJECT_PATH = '/com/kugiigi/indicator/darkmode'
 BUS_OBJECT_PATH_PHONE = BUS_OBJECT_PATH + '/phone'

--- a/po/de.po
+++ b/po/de.po
@@ -7,26 +7,26 @@ msgid ""
 msgstr ""
 "Project-Id-Version: indicator-darkmode.kugiigi\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-19 19:12+0000\n"
-"PO-Revision-Date: 2020-06-19 21:31+0200\n"
+"POT-Creation-Date: 2020-06-27 19:20+0000\n"
+"PO-Revision-Date: 2020-06-27 21:22+0200\n"
+"Last-Translator: Daniel Frost <one@frostinfo.de>\n"
 "Language-Team: \n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3.1\n"
-"Last-Translator: Daniel Frost <one@frostinfo.de>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: de\n"
 
-#: ../qml/Main.qml:30
+#: ../qml/Main.qml:33
 msgid "Suru Dark mode Indicator"
 msgstr "Suru Dark Design Indikator"
 
-#: ../qml/Main.qml:60
+#: ../qml/Main.qml:75 ../qml/Main.qml:127
 msgid "What is this?"
 msgstr "Was ist das überhaupt?"
 
-#: ../qml/Main.qml:69
+#: ../qml/Main.qml:136
 msgid ""
 "This is a proof of concept for an indicator to switch between Ambiance and "
 "Suru Dark theme."
@@ -34,11 +34,11 @@ msgstr ""
 "Dies ist ein Machbarkeitstest für einen Indikator um zwischen dem Ambiance "
 "und dem SuruDark Designs zu wechseln."
 
-#: ../qml/Main.qml:76
+#: ../qml/Main.qml:143
 msgid "What does it exactly do?"
 msgstr "Was genau passiert hier?"
 
-#: ../qml/Main.qml:85
+#: ../qml/Main.qml:152
 msgid ""
 "It modifies the theme in the config file \"/home/phablet/.config/ubuntu-ui-"
 "toolkit/theme.ini\""
@@ -46,31 +46,31 @@ msgstr ""
 "Es ändert das in der Config-Datei \"/home/phablet/.config/ubuntu-ui-toolkit/"
 "theme.ini\" gespeicherte Design"
 
-#: ../qml/Main.qml:92
+#: ../qml/Main.qml:159
 msgid "How does it work?"
 msgstr "Wie funktioniert das?"
 
-#: ../qml/Main.qml:101
+#: ../qml/Main.qml:168
 msgid ""
 "Enabling Dark Mode from the indicator will switch to the theme \"Suru Dark"
 "\". "
 msgstr ""
 "Das aktivieren von Dark Mode im Indikator wechselt zum Design \"Suru Dark\". "
 
-#: ../qml/Main.qml:102
+#: ../qml/Main.qml:169
 msgid "Disabling it will revert back to \"Ambiance\". "
 msgstr "Deaktivieren wechselt zurück zu \"Ambiance\". "
 
-#: ../qml/Main.qml:103
+#: ../qml/Main.qml:170
 msgid ""
 "There is also an option to switch the theme automatically based on the time."
 msgstr "Es gibt weiterhin eine Option um das Design zeitbasiert zu wechseln."
 
-#: ../qml/Main.qml:110
+#: ../qml/Main.qml:177
 msgid "Anything else?"
 msgstr "Noch etwas?"
 
-#: ../qml/Main.qml:119
+#: ../qml/Main.qml:186
 msgid ""
 "The theme change won't take effect on currently open apps until they are "
 "restarted. "
@@ -78,7 +78,7 @@ msgstr ""
 "Das Design wird nicht für momentan geöffnete Apps aktiv, sondern erst wenn "
 "diese neu gestartet werden. "
 
-#: ../qml/Main.qml:120
+#: ../qml/Main.qml:187
 msgid ""
 "Time accuracy for automatically switching to a theme will be based on the "
 "set time interval for checking the time."
@@ -86,7 +86,39 @@ msgstr ""
 "Die Zeitgenauigkeit des zeitbasierten Designwechsels hängt vom eingestellten "
 "Prüfintervall ab."
 
-#: ../qml/Main.qml:121
+#: ../qml/Main.qml:188
+msgid ""
+"Impact on battery is still unknown but do let me know if you notice "
+"significant reduction of battery."
+msgstr ""
+"Der Einfluss auf die Akkulaufzeit ist immer noch unbekannt. Bitte gib mir "
+"Bescheid wenn du einen starken Verbrauch bemerkst."
+
+#: ../qml/Main.qml:189
+msgid ""
+"Some devices such as the Pinephone and Meizu MX4 may have less accurate "
+"scheduled switching due to their deep sleep behavior."
+msgstr ""
+"Einige Geräte wie das Pinephone oder das Meizu MX4 haben eine ungenauere "
+"Zeitschaltung wegen ihres Standbyverhaltens."
+
+#: ../qml/Main.qml:190
+msgid ""
+"For these devices, it is advised to use lower interval time and just observe "
+"the battery. "
+msgstr ""
+"Für diese Geräte wird empfohlen ein kürzeres Zeitintervall einzustellen und "
+"die Akkulaufzeit zu beobachten. "
+
+#: ../qml/Main.qml:191
+msgid ""
+"For other devices such as the Nexus 5, it's fine to set the interval to max "
+"60 minutes and it'll still be accurate."
+msgstr ""
+"Für andere Geräte wie das Nexus 5 ist die Zeitschaltung auch bei einem "
+"Intervall von 60 Minuten immer noch akkurat."
+
+#: ../qml/Main.qml:192
 msgid ""
 "Suru Dark theme support varies across apps. There are apps that just works "
 "while some will only have partial support and some won't even respect it."
@@ -95,7 +127,7 @@ msgstr ""
 "klappen gut, manche teilweise und manche unterstützen dieses Design gar "
 "nicht."
 
-#: ../qml/Main.qml:122
+#: ../qml/Main.qml:193
 msgid ""
 "Reinstall the indicator and reboot or restart Lomiri whenever an update is "
 "installed."
@@ -103,27 +135,23 @@ msgstr ""
 "Bei jedem Update müssen der Indikator und anschließend Lomiri neu gestartet "
 "werden."
 
-#: ../qml/Main.qml:161
-msgid "Auto switch"
-msgstr "Automatischer Wechsel"
+#: ../qml/Main.qml:214
+msgid "Schedule Settings"
+msgstr "Zeitschaltungseinstellungen"
 
-#: ../qml/Main.qml:162
-msgid "Automatically switch theme based on time"
-msgstr "Automatischer zeitbasierter Designwechsel"
-
-#: ../qml/Main.qml:206
+#: ../qml/Main.qml:234
 msgid "Start time"
 msgstr "Anfangszeit"
 
-#: ../qml/Main.qml:232
+#: ../qml/Main.qml:259
 msgid "End time"
 msgstr "Endzeit"
 
-#: ../qml/Main.qml:255
+#: ../qml/Main.qml:281
 msgid "Time check interval (minutes)"
 msgstr "Zeitprüfintervall (in Minuten)"
 
-#: ../qml/Main.qml:256
+#: ../qml/Main.qml:282
 msgid ""
 "This determines how often the indicator will check the time and if there's a "
 "need to toggle the theme."
@@ -131,42 +159,104 @@ msgstr ""
 "Dies bestimmt, wie oft der Indikator abgleicht, ob das Design gewechselt "
 "werden muss."
 
-#: ../qml/Main.qml:289
+#: ../qml/Main.qml:315
 msgid ""
-"Warning: The smaller the value, the higher the impact to battery. This takes "
-"effect even when auto-switching is disabled."
+"Warning: Lower value will make the scheduled switching more accurate but may "
+"impact the battery."
 msgstr ""
-"Warnung: Je häufiger geprüft wird, desto größer ist der Stromverbrauch. Dies "
-"gilt auch, wenn der automatische Wechsel deaktiviert ist."
+"Achtung: Niedrige Werte erhöhen die Genauigkeit der Zeitschaltung aber "
+"können die Akkulaufzeit beeinträchtigen."
 
-#: ../qml/Main.qml:307
+#: ../qml/Main.qml:337
+msgid "Indicator logging"
+msgstr "Logaufzeichnung für den Indikator"
+
+#: ../qml/Main.qml:338
+msgid "Useful for debugging"
+msgstr "Nützlich für die Fehlersuche"
+
+#: ../qml/Main.qml:394
 msgid "Install Indicator"
 msgstr "Indikator installieren"
 
-#: ../qml/Main.qml:307
+#: ../qml/Main.qml:394
 msgid "Uninstall Indicator"
 msgstr "Indikator deinstallieren"
 
-#: ../qml/Main.qml:321
+#: ../qml/Main.qml:409
+msgid "Restart Lomiri/Unity8"
+msgstr "Lomiri/Unity8 neu starten"
+
+#: ../qml/Main.qml:425
 msgid "Uninstall the indicator here before uninstalling the app!"
 msgstr "Vor Deinstallation der App hier den Indikator deinstallieren!"
 
-#: ../qml/Main.qml:336
+#: ../qml/Main.qml:442 ../qml/Main.qml:448
+msgid "Restart Lomiri"
+msgstr "Lomiri Neustart"
+
+#: ../qml/Main.qml:443
+msgid "Do you want to restart Lomiri now?"
+msgstr "Möchtest du jetzt Lomiri neu starten?"
+
+#: ../qml/Main.qml:444
+msgid "All currently open apps will be closed."
+msgstr "Alle offenen Apps werden geschlossen."
+
+#: ../qml/Main.qml:445
+msgid "Save all your work before continuing!"
+msgstr "Speichere alle Arbeiten bevor du fortfährst!"
+
+#: ../qml/Main.qml:457
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: ../qml/Main.qml:469
 msgid "Successfully installed!"
 msgstr "Erfolgreich installiert!"
 
-#: ../qml/Main.qml:336 ../qml/Main.qml:347
+#: ../qml/Main.qml:469 ../qml/Main.qml:481
 msgid "Please reboot or restart Lomiri/Unity8"
 msgstr "Bitte Gerät oder Lomiri/Unity8 neu starten"
 
-#: ../qml/Main.qml:340
+#: ../qml/Main.qml:474
 msgid "Failed to install"
 msgstr "Installation fehlgeschlagen"
 
-#: ../qml/Main.qml:347
+#: ../qml/Main.qml:481
 msgid "Successfully uninstalled!"
 msgstr "Erfolgreich deinstalliert!"
 
-#: ../qml/Main.qml:351
+#: ../qml/Main.qml:486
 msgid "Failed to uninstall"
 msgstr "Deinstallation fehlgeschlagen"
+
+#: ../indicator/kugiigi-indicator-darkmode.py:57
+msgid "Indicator Suru Dark Mode"
+msgstr "SuruDark Design Indikator"
+
+#: ../indicator/kugiigi-indicator-darkmode.py:104
+msgid "Scheduled"
+msgstr "Zeitschaltung"
+
+#: ../indicator/kugiigi-indicator-darkmode.py:109
+#: ../indicator/kugiigi-indicator-darkmode.py:122
+msgid "Suru Dark Mode"
+msgstr "Suru Dark Design"
+
+#: ../indicator/kugiigi-indicator-darkmode.py:113
+msgid "Suru Dark Mode Settings..."
+msgstr "Suru Dark Design Einstellungen..."
+
+#~ msgid "Auto switch"
+#~ msgstr "Automatischer Wechsel"
+
+#~ msgid "Automatically switch theme based on time"
+#~ msgstr "Automatischer zeitbasierter Designwechsel"
+
+#~ msgid ""
+#~ "Warning: The smaller the value, the higher the impact to battery. This "
+#~ "takes effect even when auto-switching is disabled."
+#~ msgstr ""
+#~ "Warnung: Je häufiger geprüft wird, desto größer ist der Stromverbrauch. "
+#~ "Dies gilt auch, wenn der automatische Wechsel deaktiviert ist."

--- a/po/indicator-darkmode.pot
+++ b/po/indicator-darkmode.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: indicator-darkmode.kugiigi\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-26 13:16+0800\n"
+"POT-Creation-Date: 2020-06-27 19:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -202,4 +202,21 @@ msgstr ""
 
 #: ../qml/Main.qml:486
 msgid "Failed to uninstall"
+msgstr ""
+
+#: ../indicator/kugiigi-indicator-darkmode.py:57
+msgid "Indicator Suru Dark Mode"
+msgstr ""
+
+#: ../indicator/kugiigi-indicator-darkmode.py:104
+msgid "Scheduled"
+msgstr ""
+
+#: ../indicator/kugiigi-indicator-darkmode.py:109
+#: ../indicator/kugiigi-indicator-darkmode.py:122
+msgid "Suru Dark Mode"
+msgstr ""
+
+#: ../indicator/kugiigi-indicator-darkmode.py:113
+msgid "Suru Dark Mode Settings..."
 msgstr ""


### PR DESCRIPTION
Sneaking through Brians indicator weather I learned how to make the indicator strings translatable. Here you go ...
Updated pot file with those strings.
And updated German translation - including those new strings.

P.S. Not sure why it did those delete/add empty lines thing. :thinking: 